### PR TITLE
fix: SignUpRequestのaddressをint型のareaに変更

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -391,14 +391,14 @@ components:
       required:
         - username
         - password
-        - address
+        - area
       properties:
         username:
           type: string
         password:
           type: string
-        address:
-          type: string
+        area:
+          type: integer
     LoginRequest:
       type: object
       required:


### PR DESCRIPTION
## issue番号

#73 

<!-- #1 -->
<!-- #<Issueの番号> -->

## やったこと(簡単でOK)

- openapi.yamlのSignUpRequestスキーマを修正
- string型のaddressで地域を管理していたが、以前のMTGでint型で管理することに決定したため


<!-- このプルリクで何をしたのか？ -->
<!-- UI変更がある場合は画像があると嬉しい -->

## その他(Option)

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- この変更に伴うopenapiのコード自動生成は行っていない

<!-- Closes #<紐付けたいIssueの番号> (Pull RequestとIssueを紐付けてクローズさせる) -->
Closes #73 
