### PR TITLE
webAPI上でのログインのレスポンスを変更

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -450,10 +450,10 @@ components:
       type: object
     LoginResponse:
       example:
-        userId: 0
+        user_id: 0
       properties:
-        userId:
-          title: userId
+        user_id:
+          title: user_id
           type: integer
       title: LoginResponse
       type: object

--- a/backend/src/openapi_server/models/login_response.py
+++ b/backend/src/openapi_server/models/login_response.py
@@ -31,8 +31,8 @@ class LoginResponse(BaseModel):
     """
     LoginResponse
     """ # noqa: E501
-    user_id: Optional[StrictInt] = Field(default=None, alias="userId")
-    __properties: ClassVar[List[str]] = ["userId"]
+    user_id: Optional[StrictInt] = Field(default=None, alias="user_id")
+    __properties: ClassVar[List[str]] = ["user_id"]
 
     model_config = {
         "populate_by_name": True,
@@ -83,7 +83,7 @@ class LoginResponse(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "userId": obj.get("userId")
+            "user_id": obj.get("user_id")
         })
         return _obj
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -411,7 +411,7 @@ components:
     LoginResponse:
       type: object
       properties:
-        userId:
+        user_id:
           type: integer
     RegisterFurnitureRequest:
       type: object


### PR DESCRIPTION
## issue番号

#89 

## やったこと(簡単でOK)

- DBや他API上でuser_idという名前で統一されているためuserId ->user_idに変更

## その他(Option)

- クライアント側ですでにuserIdで実装していたらすみません！！！

#89 
