### PR TITLE
MTGで話したAPI定義を追加

### DIFF
--- a/backend/.openapi-generator/FILES
+++ b/backend/.openapi-generator/FILES
@@ -2,11 +2,10 @@
 openapi.yaml
 setup.cfg
 src/openapi_server/apis/__init__.py
-src/openapi_server/apis/favorite_api.py
 src/openapi_server/apis/favorite_api_base.py
+src/openapi_server/apis/furniture_api.py
+src/openapi_server/apis/furniture_api_base.py
 src/openapi_server/apis/ok_api_base.py
-src/openapi_server/apis/recommendation_api.py
-src/openapi_server/apis/recommendation_api_base.py
 src/openapi_server/apis/trade_api.py
 src/openapi_server/apis/trade_api_base.py
 src/openapi_server/apis/user_api_base.py
@@ -14,6 +13,7 @@ src/openapi_server/models/__init__.py
 src/openapi_server/models/error_response.py
 src/openapi_server/models/extra_models.py
 src/openapi_server/models/favorite_response.py
+src/openapi_server/models/furniture_describe_response.py
 src/openapi_server/models/furniture_list_request.py
 src/openapi_server/models/furniture_list_response.py
 src/openapi_server/models/furniture_request.py
@@ -21,9 +21,6 @@ src/openapi_server/models/furniture_response.py
 src/openapi_server/models/login_request.py
 src/openapi_server/models/login_response.py
 src/openapi_server/models/ok_response.py
-src/openapi_server/models/recommend_request.py
-src/openapi_server/models/recommend_response.py
-src/openapi_server/models/recommend_response_recommendations_inner.py
 src/openapi_server/models/request_trade_request.py
 src/openapi_server/models/sign_up_request.py
 src/openapi_server/models/trade_list_response.py

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -17,8 +17,6 @@ tags:
   name: Trade
 - description: いいね機能
   name: Favorite
-- description: レコメンド機能
-  name: Recommendation
 paths:
   /ok:
     get:
@@ -168,6 +166,54 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: validation error
       summary: Get furniture details
+      tags:
+      - Furniture
+  /furniture/describe:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FurnitureDescribeRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FurnitureDescribeResponse'
+          description: Furniture described successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: validation error
+      summary: Generate furniture description
+      tags:
+      - Furniture
+  /furniture/recommend:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FurnitureRecommendRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FurnitureListResponse'
+          description: Furniture recommended successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: validation error
+      summary: Recommend furniture
       tags:
       - Furniture
   /trades:
@@ -373,24 +419,6 @@ paths:
       summary: Get favorite status
       tags:
       - Favorite
-  /recommend:
-    get:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecommendRequest'
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecommendResponse'
-          description: Furniture recommendations retrieved successfully
-      summary: Get furniture recommendations based on room photo
-      tags:
-      - Recommendation
 components:
   schemas:
     OKResponse:
@@ -647,6 +675,49 @@ components:
           type: boolean
       title: FurnitureResponse
       type: object
+    FurnitureDescribeRequest:
+      properties:
+        image:
+          format: binary
+          type: string
+      required:
+      - image
+      type: object
+    FurnitureDescribeResponse:
+      example:
+        color: 6
+        description: description
+        category: 0
+        product_name: product_name
+      properties:
+        product_name:
+          title: product_name
+          type: string
+        description:
+          title: description
+          type: string
+        category:
+          description: カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
+          title: category
+          type: integer
+        color:
+          description: 色コード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
+          title: color
+          type: integer
+      title: FurnitureDescribeResponse
+      type: object
+    FurnitureRecommendRequest:
+      properties:
+        room_photo:
+          format: binary
+          type: string
+        category:
+          description: カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
+          type: integer
+      required:
+      - category
+      - room_photo
+      type: object
     RequestTradeRequest:
       example:
         furnitureId: 0
@@ -790,62 +861,4 @@ components:
           title: favorites_count
           type: integer
       title: FavoriteResponse
-      type: object
-    RecommendRequest:
-      example:
-        roomPhoto: roomPhoto
-      properties:
-        roomPhoto:
-          title: roomPhoto
-          type: string
-      required:
-      - roomPhoto
-      title: RecommendRequest
-      type: object
-    RecommendResponse:
-      example:
-        recommendations:
-        - image: ""
-          size: size
-          description: description
-          furnitureId: 0
-          category: category
-        - image: ""
-          size: size
-          description: description
-          furnitureId: 0
-          category: category
-      properties:
-        recommendations:
-          items:
-            $ref: '#/components/schemas/RecommendResponse_recommendations_inner'
-          title: recommendations
-          type: array
-      title: RecommendResponse
-      type: object
-    RecommendResponse_recommendations_inner:
-      example:
-        image: ""
-        size: size
-        description: description
-        furnitureId: 0
-        category: category
-      properties:
-        furnitureId:
-          title: furnitureId
-          type: integer
-        image:
-          format: binary
-          title: image
-          type: string
-        description:
-          title: description
-          type: string
-        size:
-          title: size
-          type: string
-        category:
-          title: category
-          type: string
-      title: RecommendResponse_recommendations_inner
       type: object

--- a/backend/src/openapi_server/apis/furniture_api.py
+++ b/backend/src/openapi_server/apis/furniture_api.py
@@ -24,6 +24,7 @@ from fastapi import (  # noqa: F401
 
 from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.models.error_response import ErrorResponse
+from openapi_server.models.furniture_describe_response import FurnitureDescribeResponse
 from openapi_server.models.furniture_list_request import FurnitureListRequest
 from openapi_server.models.furniture_list_response import FurnitureListResponse
 from openapi_server.models.furniture_request import FurnitureRequest
@@ -41,6 +42,22 @@ router = APIRouter()
 ns_pkg = openapi_server.impl
 for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
     importlib.import_module(name)
+
+
+@router.post(
+    "/furniture/describe",
+    responses={
+        200: {"model": FurnitureDescribeResponse, "description": "Furniture described successfully"},
+        400: {"model": ErrorResponse, "description": "validation error"},
+    },
+    tags=["Furniture"],
+    summary="Generate furniture description",
+    response_model_by_alias=True,
+)
+async def furniture_describe_post(
+    image: str = Form(None, description=""),
+) -> FurnitureDescribeResponse:
+    ...
 
 
 @router.delete(
@@ -135,3 +152,20 @@ async def furniture_post(
         condition,
         db
     )
+
+
+@router.post(
+    "/furniture/recommend",
+    responses={
+        200: {"model": FurnitureListResponse, "description": "Furniture recommended successfully"},
+        400: {"model": ErrorResponse, "description": "validation error"},
+    },
+    tags=["Furniture"],
+    summary="Recommend furniture",
+    response_model_by_alias=True,
+)
+async def furniture_recommend_post(
+    room_photo: UploadFile = Form(..., description=""),
+    category: int = Form(..., description="カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)"),
+) -> FurnitureListResponse:
+    ...

--- a/backend/src/openapi_server/apis/furniture_api_base.py
+++ b/backend/src/openapi_server/apis/furniture_api_base.py
@@ -3,6 +3,7 @@
 from typing import ClassVar, Dict, List, Tuple  # noqa: F401
 
 from openapi_server.models.error_response import ErrorResponse
+from openapi_server.models.furniture_describe_response import FurnitureDescribeResponse
 from openapi_server.models.furniture_list_request import FurnitureListRequest
 from openapi_server.models.furniture_list_response import FurnitureListResponse
 from openapi_server.models.furniture_request import FurnitureRequest
@@ -17,6 +18,13 @@ class BaseFurnitureApi:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         BaseFurnitureApi.subclasses = BaseFurnitureApi.subclasses + (cls,)
+    def furniture_describe_post(
+        self,
+        image: str,
+    ) -> FurnitureDescribeResponse:
+        ...
+
+
     def furniture_furniture_id_delete(
         self,
         furniture_id: int,
@@ -55,4 +63,12 @@ class BaseFurnitureApi:
         trade_place: str,
         condition: int,
     ) -> FurnitureResponse:
+        ...
+
+
+    def furniture_recommend_post(
+        self,
+        room_photo: UploadFile,
+        category: int,
+    ) -> FurnitureListResponse:
         ...

--- a/backend/src/openapi_server/models/furniture_describe_response.py
+++ b/backend/src/openapi_server/models/furniture_describe_response.py
@@ -20,19 +20,22 @@ import json
 
 
 
-from pydantic import BaseModel, ConfigDict, StrictInt
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 try:
     from typing import Self
 except ImportError:
     from typing_extensions import Self
 
-class LoginResponse(BaseModel):
+class FurnitureDescribeResponse(BaseModel):
     """
-    LoginResponse
+    FurnitureDescribeResponse
     """ # noqa: E501
-    user_id: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["user_id"]
+    product_name: Optional[StrictStr] = None
+    description: Optional[StrictStr] = None
+    category: Optional[StrictInt] = Field(default=None, description="カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)")
+    color: Optional[StrictInt] = Field(default=None, description="色コード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)")
+    __properties: ClassVar[List[str]] = ["product_name", "description", "category", "color"]
 
     model_config = {
         "populate_by_name": True,
@@ -52,7 +55,7 @@ class LoginResponse(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:
-        """Create an instance of LoginResponse from a JSON string"""
+        """Create an instance of FurnitureDescribeResponse from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -75,7 +78,7 @@ class LoginResponse(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Dict) -> Self:
-        """Create an instance of LoginResponse from a dict"""
+        """Create an instance of FurnitureDescribeResponse from a dict"""
         if obj is None:
             return None
 
@@ -83,7 +86,10 @@ class LoginResponse(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "user_id": obj.get("user_id")
+            "product_name": obj.get("product_name"),
+            "description": obj.get("description"),
+            "category": obj.get("category"),
+            "color": obj.get("color")
         })
         return _obj
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -17,8 +17,6 @@ tags:
     description: 取引機能
   - name: Favorite
     description: いいね機能
-  - name: Recommendation
-    description: レコメンド機能
 
 paths:
   /ok:
@@ -167,6 +165,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /furniture/describe:
+    post:
+      tags:
+        - Furniture
+      summary: Generate furniture description
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FurnitureDescribeRequest'
+      responses:
+        '200':
+          description: Furniture described successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FurnitureDescribeResponse'
+        '400':
+          description: validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /furniture/recommend:
+    post:
+      tags:
+        - Furniture
+      summary: Recommend furniture
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FurnitureRecommendRequest'
+      responses:
+        '200':
+          description: Furniture recommended successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FurnitureListResponse'
+        '400':
+          description: validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /trades:
     post:
       tags:
@@ -353,26 +400,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-
-  /recommend:
-    get:
-      tags:
-        - Recommendation
-      summary: Get furniture recommendations based on room photo
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecommendRequest'
-      responses:
-        '200':
-          description: Furniture recommendations retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecommendResponse'
-
 components:
   schemas:
     OKResponse:
@@ -527,6 +554,39 @@ components:
         is_favorite:
           type: boolean
           description: 「いいねした商品」用
+    FurnitureDescribeRequest:
+      type: object
+      required:
+        - image
+      properties:
+        image:
+          type: string
+          format: binary
+    FurnitureDescribeResponse:
+      type: object
+      properties:
+        product_name:
+          type: string
+        description:
+          type: string
+        category:
+          type: integer
+          description: カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
+        color:
+          type: integer
+          description: 色コード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
+    FurnitureRecommendRequest:
+      type: object
+      required:
+        - room_photo
+        - category
+      properties:
+        room_photo:
+          type: string
+          format: binary
+        category:
+          type: integer
+          description: カテゴリコード(https://github.com/naka-c1024/Pasha-niture/blob/main/client/app/lib/Domain/constants.dart)
     RequestTradeRequest:
       type: object
       required:
@@ -597,29 +657,3 @@ components:
       properties:
         favorites_count:
           type: integer
-    RecommendRequest:
-      type: object
-      required:
-        - roomPhoto
-      properties:
-        roomPhoto:
-          type: string
-    RecommendResponse:
-      type: object
-      properties:
-        recommendations:
-          type: array
-          items:
-            type: object
-            properties:
-              furnitureId:
-                type: integer
-              image:
-                type: string
-                format: binary
-              description:
-                type: string
-              size:
-                type: string
-              category:
-                type: string


### PR DESCRIPTION
## issue番号

なし！

## やったこと(簡単でOK)

- レコメンド機能のAPI定義追加
- 家具登録時の設定値自動生成機能のAPI定義追加
- `openapitools/openapi-generator-cli`でコード自動生成

## その他(Option)

6/20のMTGで話し合ったAPI設計です
おかしな部分があったら適宜修正お願いします🙏