### PR TITLE
TradeAPIの実装

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -649,43 +649,43 @@ components:
       type: object
     RequestTradeRequest:
       example:
-        furnitureId: 0
-        userId: 6
+        furniture_id: 0
+        user_id: 6
         trade_date: 2000-01-23
       properties:
-        furnitureId:
-          title: furnitureId
+        furniture_id:
+          title: furniture_id
           type: integer
-        userId:
-          title: userId
+        user_id:
+          title: user_id
           type: integer
         trade_date:
           format: date
           title: trade_date
           type: string
       required:
-      - furnitureId
+      - furniture_id
       - trade_date
-      - userId
+      - user_id
       title: RequestTradeRequest
       type: object
     TradeResponse:
       example:
         image: ""
-        giverId: 1
-        receiverId: 5
+        giver_id: 1
+        receiver_id: 5
         giver_approval: true
         receiver_approval: true
         receiver_name: receiver_name
         is_checked: true
         trade_place: trade_place
-        furnitureId: 6
+        furniture_id: 6
         product_name: product_name
         trade_date: 2000-01-23
-        tradeId: 0
+        trade_id: 0
       properties:
-        tradeId:
-          title: tradeId
+        trade_id:
+          title: trade_id
           type: integer
         image:
           format: binary
@@ -701,14 +701,14 @@ components:
           description: 具体的な取引場所
           title: trade_place
           type: string
-        furnitureId:
-          title: furnitureId
+        furniture_id:
+          title: furniture_id
           type: integer
-        giverId:
-          title: giverId
+        giver_id:
+          title: giver_id
           type: integer
-        receiverId:
-          title: receiverId
+        receiver_id:
+          title: receiver_id
           type: integer
         is_checked:
           title: is_checked
@@ -729,29 +729,29 @@ components:
       example:
         trades:
         - image: ""
-          giverId: 1
-          receiverId: 5
+          giver_id: 1
+          receiver_id: 5
           giver_approval: true
           receiver_approval: true
           receiver_name: receiver_name
           is_checked: true
           trade_place: trade_place
-          furnitureId: 6
+          furniture_id: 6
           product_name: product_name
           trade_date: 2000-01-23
-          tradeId: 0
+          trade_id: 0
         - image: ""
-          giverId: 1
-          receiverId: 5
+          giver_id: 1
+          receiver_id: 5
           giver_approval: true
           receiver_approval: true
           receiver_name: receiver_name
           is_checked: true
           trade_place: trade_place
-          furnitureId: 6
+          furniture_id: 6
           product_name: product_name
           trade_date: 2000-01-23
-          tradeId: 0
+          trade_id: 0
       properties:
         trades:
           items:

--- a/backend/src/openapi_server/apis/trade_api.py
+++ b/backend/src/openapi_server/apis/trade_api.py
@@ -29,6 +29,11 @@ from openapi_server.models.trade_response import TradeResponse
 from openapi_server.models.update_approval_request import UpdateApprovalRequest
 from openapi_server.models.update_is_checked_request import UpdateIsCheckedRequest
 
+from openapi_server.impl.trade_api_impl import TradeApiImpl
+from sqlalchemy.ext.asyncio import AsyncSession
+from openapi_server.db import get_db
+
+impl = TradeApiImpl()
 
 router = APIRouter()
 
@@ -48,8 +53,9 @@ for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
 )
 async def trades_get(
     user_id: int = Query(None, description="", alias="user_id"),
+    db: AsyncSession = Depends(get_db),
 ) -> TradeListResponse:
-    ...
+    return await impl.trades_get(user_id, db)
 
 
 @router.post(
@@ -64,8 +70,9 @@ async def trades_get(
 )
 async def trades_post(
     request_trade_request: RequestTradeRequest = Body(None, description=""),
+    db: AsyncSession = Depends(get_db),
 ) -> None:
-    ...
+    return await impl.trades_post(request_trade_request, db)
 
 
 @router.get(
@@ -80,8 +87,9 @@ async def trades_post(
 )
 async def trades_trade_id_get(
     trade_id: int = Path(..., description=""),
+    db: AsyncSession = Depends(get_db),
 ) -> TradeResponse:
-    ...
+    return await impl.trades_trade_id_get(trade_id, db)
 
 
 @router.put(
@@ -97,8 +105,9 @@ async def trades_trade_id_get(
 async def trades_trade_id_is_checked_put(
     trade_id: int = Path(..., description=""),
     update_is_checked_request: UpdateIsCheckedRequest = Body(None, description=""),
+    db: AsyncSession = Depends(get_db),
 ) -> None:
-    ...
+    return await impl.trades_trade_id_is_checked_put(trade_id, update_is_checked_request, db)
 
 
 @router.put(
@@ -114,5 +123,6 @@ async def trades_trade_id_is_checked_put(
 async def trades_trade_id_put(
     trade_id: int = Path(..., description=""),
     update_approval_request: UpdateApprovalRequest = Body(None, description=""),
+    db: AsyncSession = Depends(get_db),
 ) -> None:
-    ...
+    return await impl.trades_trade_id_put(trade_id, update_approval_request, db)

--- a/backend/src/openapi_server/apis/trade_api.py
+++ b/backend/src/openapi_server/apis/trade_api.py
@@ -41,23 +41,6 @@ ns_pkg = openapi_server.impl
 for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
     importlib.import_module(name)
 
-
-@router.get(
-    "/trades",
-    responses={
-        200: {"model": TradeListResponse, "description": "Trade list retrieved successfully"},
-    },
-    tags=["Trade"],
-    summary="Get list of trades history",
-    response_model_by_alias=True,
-)
-async def trades_get(
-    user_id: int = Query(None, description="", alias="user_id"),
-    db: AsyncSession = Depends(get_db),
-) -> TradeListResponse:
-    return await impl.trades_get(user_id, db)
-
-
 @router.post(
     "/trades",
     responses={
@@ -74,6 +57,20 @@ async def trades_post(
 ) -> None:
     return await impl.trades_post(request_trade_request, db)
 
+@router.get(
+    "/trades",
+    responses={
+        200: {"model": TradeListResponse, "description": "Trade list retrieved successfully"},
+    },
+    tags=["Trade"],
+    summary="Get list of trades history",
+    response_model_by_alias=True,
+)
+async def trades_get(
+    user_id: int = Query(None, description="", alias="user_id"),
+    db: AsyncSession = Depends(get_db),
+) -> TradeListResponse:
+    return await impl.trades_get(user_id, db)
 
 @router.get(
     "/trades/{trade_id}",

--- a/backend/src/openapi_server/cruds/trade.py
+++ b/backend/src/openapi_server/cruds/trade.py
@@ -1,0 +1,15 @@
+from  sqlalchemy.ext.asyncio import AsyncSession
+
+import openapi_server.db_model.tables as db_model
+
+from openapi_server.models.request_trade_request import RequestTradeRequest
+
+async def create_trade(
+    db: AsyncSession,
+    request_trade_request: RequestTradeRequest
+):
+    print(request_trade_request.dict())
+    trade = db_model.Trades(**request_trade_request.dict())
+    db.add(trade)
+    await db.commit()
+    await db.refresh(trade)

--- a/backend/src/openapi_server/cruds/trade.py
+++ b/backend/src/openapi_server/cruds/trade.py
@@ -1,22 +1,67 @@
 from  sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.engine import Result
 
-import openapi_server.db_model.tables as db_model
+from openapi_server.db_model.tables import Trades, Furniture
 
 from openapi_server.models.request_trade_request import RequestTradeRequest
+from openapi_server.models.trade_list_response import TradeListResponse
+from openapi_server.models.trade_response import TradeResponse
+
+from openapi_server.cruds.user_api import get_user
+
+from typing import List, Tuple, Optional
 
 async def create_trade(
     db: AsyncSession,
     request_trade_request: RequestTradeRequest
 ):
-    trade_request = {
-        "furniture_id"      : request_trade_request.furniture_id,
-        "receiver_id"       : request_trade_request.user_id,
-        "is_checked"        : False,
-        "giver_approval"    : False,
-        "receiver_approval" : False,
-        "trade_date"        : request_trade_request.trade_date
-    }
-    trade = db_model.Trades(**trade_request)
+    trade = Trades(
+        furniture_id        = request_trade_request.furniture_id,
+        receiver_id         = request_trade_request.user_id,
+        is_checked          = False,
+        giver_approval      = False,
+        receiver_approval   = False,
+        trade_date          = request_trade_request.trade_date
+        
+    )
     db.add(trade)
     await db.commit()
     await db.refresh(trade)
+
+async def get_trades(
+    db: AsyncSession,
+    user_id: int
+) -> TradeListResponse:
+    query = select(
+        Trades,
+        Furniture
+    ).join(Furniture, Trades.furniture_id == Furniture.furniture_id).where(
+        (Trades.receiver_id == user_id) | (Furniture.user_id == user_id)
+    )
+
+    result: Result = await db.execute(query)
+    trades = result.all()
+    if not trades:
+        return None
+
+    trade_list_response = []
+    for trade in trades:
+        user = await get_user(db, trade.Furniture.user_id)
+        trade_list_response.append(
+            TradeResponse(
+                trade_id            = trade.Trades.trade_id,
+                image               = trade.Furniture.image,
+                receiver_name       = user.username,
+                product_name        = trade.Furniture.product_name,
+                trade_place         = trade.Furniture.trade_place,
+                furniture_id        = trade.Furniture.user_id,
+                giver_id            = trade.Furniture.user_id,
+                receiver_id         = trade.Trades.receiver_id,
+                is_checked          = trade.Trades.is_checked,
+                giver_approval      = trade.Trades.giver_approval,
+                receiver_approval   = trade.Trades.receiver_approval,
+                trade_date          = trade.Trades.trade_date,
+            )
+        )
+    return TradeListResponse(trades=trade_list_response)

--- a/backend/src/openapi_server/cruds/trade.py
+++ b/backend/src/openapi_server/cruds/trade.py
@@ -8,8 +8,15 @@ async def create_trade(
     db: AsyncSession,
     request_trade_request: RequestTradeRequest
 ):
-    print(request_trade_request.dict())
-    trade = db_model.Trades(**request_trade_request.dict())
+    trade_request = {
+        "furniture_id"      : request_trade_request.furniture_id,
+        "receiver_id"       : request_trade_request.user_id,
+        "is_checked"        : False,
+        "giver_approval"    : False,
+        "receiver_approval" : False,
+        "trade_date"        : request_trade_request.trade_date
+    }
+    trade = db_model.Trades(**trade_request)
     db.add(trade)
     await db.commit()
     await db.refresh(trade)

--- a/backend/src/openapi_server/cruds/trade.py
+++ b/backend/src/openapi_server/cruds/trade.py
@@ -29,7 +29,7 @@ async def create_trade(
     await db.commit()
     await db.refresh(trade)
 
-async def get_trades(
+async def get_trade_list(
     db: AsyncSession,
     user_id: int
 ) -> TradeListResponse:
@@ -65,3 +65,35 @@ async def get_trades(
             )
         )
     return TradeListResponse(trades=trade_list_response)
+
+async def get_trade(
+    db: AsyncSession,
+    trade_id: int
+) -> TradeResponse:
+    query = select(
+        Trades,
+        Furniture
+    ).join(Furniture, Trades.furniture_id == Furniture.furniture_id).where(
+        Trades.trade_id == trade_id
+    )
+
+    result: Result = await db.execute(query)
+    trade = result.first()
+    if not trade:
+        return None
+
+    user = await get_user(db, trade.Furniture.user_id)
+    return TradeResponse(
+        trade_id            = trade.Trades.trade_id,
+        image               = trade.Furniture.image,
+        receiver_name       = user.username,
+        product_name        = trade.Furniture.product_name,
+        trade_place         = trade.Furniture.trade_place,
+        furniture_id        = trade.Furniture.user_id,
+        giver_id            = trade.Furniture.user_id,
+        receiver_id         = trade.Trades.receiver_id,
+        is_checked          = trade.Trades.is_checked,
+        giver_approval      = trade.Trades.giver_approval,
+        receiver_approval   = trade.Trades.receiver_approval,
+        trade_date          = trade.Trades.trade_date,
+    )

--- a/backend/src/openapi_server/impl/trade_api_impl.py
+++ b/backend/src/openapi_server/impl/trade_api_impl.py
@@ -15,6 +15,7 @@ class TradeApiImpl(BaseTradeApi):
         return TradeListResponse()
 
     async def trades_post(self, request_trade_request: RequestTradeRequest, db: AsyncSession) -> None:
+        await trade_crud.create_trade(db, request_trade_request)
         return None
 
     async def trades_trade_id_get(self, trade_id: int, db: AsyncSession) -> TradeResponse:

--- a/backend/src/openapi_server/impl/trade_api_impl.py
+++ b/backend/src/openapi_server/impl/trade_api_impl.py
@@ -13,18 +13,59 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 class TradeApiImpl(BaseTradeApi):
-    async def trades_get(self, user_id: int, db: AsyncSession) -> TradeListResponse:
-        return await trade_crud.get_trade_list(db, user_id)
-
     async def trades_post(self, request_trade_request: RequestTradeRequest, db: AsyncSession) -> None:
         await trade_crud.create_trade(db, request_trade_request)
         return None
 
+    async def trades_get(self, user_id: int, db: AsyncSession) -> TradeListResponse:
+        trades = await trade_crud.get_trade(db, user_id=user_id)
+        if not trades:
+            raise HTTPException(status_code=404, detail="Trade not found")
+        
+        return TradeListResponse(trades=[
+            TradeResponse(
+                image               = trade.Furniture.image,
+                receiver_name       = trade.Users.username,
+                product_name        = trade.Furniture.product_name,
+                trade_place         = trade.Furniture.trade_place,
+                furniture_id        = trade.Furniture.user_id,
+                giver_id            = trade.Furniture.user_id,
+                receiver_id         = trade.Trades.receiver_id,
+                is_checked          = trade.Trades.is_checked,
+                giver_approval      = trade.Trades.giver_approval,
+                receiver_approval   = trade.Trades.receiver_approval,
+                trade_date          = trade.Trades.trade_date,
+            )
+            for trade in trades
+        ])
+
     async def trades_trade_id_get(self, trade_id: int, db: AsyncSession) -> TradeResponse:
-        return await trade_crud.get_trade(db, trade_id)
+        trades = await trade_crud.get_trade(db, trade_id=trade_id)
+        if not trades:
+            raise HTTPException(status_code=404, detail="Trade not found")
+        
+        return TradeResponse(
+            image               = trades[0].Furniture.image,
+            receiver_name       = trades[0].Users.username,
+            product_name        = trades[0].Furniture.product_name,
+            trade_place         = trades[0].Furniture.trade_place,
+            furniture_id        = trades[0].Furniture.user_id,
+            giver_id            = trades[0].Furniture.user_id,
+            receiver_id         = trades[0].Trades.receiver_id,
+            is_checked          = trades[0].Trades.is_checked,
+            giver_approval      = trades[0].Trades.giver_approval,
+            receiver_approval   = trades[0].Trades.receiver_approval,
+            trade_date          = trades[0].Trades.trade_date,
+        )
 
     async def trades_trade_id_is_checked_put(self, trade_id: int, update_is_checked_request: UpdateIsCheckedRequest, db: AsyncSession) -> None:
+        trade = await trade_crud.update_is_checked(db, trade_id, update_is_checked_request)
+        if not trade:
+            raise HTTPException(status_code=404, detail="Trade not found")
         return None
 
     async def trades_trade_id_put(self, trade_id: int, update_trade_request: UpdateTradeRequest, db: AsyncSession) -> TradeResponse:
+        trade = await trade_crud.update_trade(db, trade_id, update_trade_request)
+        if not trade:
+            raise HTTPException(status_code=404, detail="Trade not found")
         return None

--- a/backend/src/openapi_server/impl/trade_api_impl.py
+++ b/backend/src/openapi_server/impl/trade_api_impl.py
@@ -8,11 +8,13 @@ from openapi_server.models.trade_response import TradeResponse
 
 import openapi_server.cruds.trade as trade_crud
 
+from fastapi import HTTPException
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 class TradeApiImpl(BaseTradeApi):
     async def trades_get(self, user_id: int, db: AsyncSession) -> TradeListResponse:
-        return TradeListResponse()
+        return await trade_crud.get_trades(db, user_id)
 
     async def trades_post(self, request_trade_request: RequestTradeRequest, db: AsyncSession) -> None:
         await trade_crud.create_trade(db, request_trade_request)

--- a/backend/src/openapi_server/impl/trade_api_impl.py
+++ b/backend/src/openapi_server/impl/trade_api_impl.py
@@ -14,14 +14,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 class TradeApiImpl(BaseTradeApi):
     async def trades_get(self, user_id: int, db: AsyncSession) -> TradeListResponse:
-        return await trade_crud.get_trades(db, user_id)
+        return await trade_crud.get_trade_list(db, user_id)
 
     async def trades_post(self, request_trade_request: RequestTradeRequest, db: AsyncSession) -> None:
         await trade_crud.create_trade(db, request_trade_request)
         return None
 
     async def trades_trade_id_get(self, trade_id: int, db: AsyncSession) -> TradeResponse:
-        return TradeResponse()
+        return await trade_crud.get_trade(db, trade_id)
 
     async def trades_trade_id_is_checked_put(self, trade_id: int, update_is_checked_request: UpdateIsCheckedRequest, db: AsyncSession) -> None:
         return None

--- a/backend/src/openapi_server/impl/trade_api_impl.py
+++ b/backend/src/openapi_server/impl/trade_api_impl.py
@@ -1,0 +1,27 @@
+from openapi_server.models.update_is_checked_request import UpdateIsCheckedRequest
+from openapi_server.apis.trade_api_base import BaseTradeApi
+
+from openapi_server.models.update_trade_request import UpdateTradeRequest
+from openapi_server.models.request_trade_request import RequestTradeRequest
+from openapi_server.models.trade_list_response import TradeListResponse
+from openapi_server.models.trade_response import TradeResponse
+
+import openapi_server.cruds.trade as trade_crud
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+class TradeApiImpl(BaseTradeApi):
+    async def trades_get(self, user_id: int, db: AsyncSession) -> TradeListResponse:
+        return TradeListResponse()
+
+    async def trades_post(self, request_trade_request: RequestTradeRequest, db: AsyncSession) -> None:
+        return None
+
+    async def trades_trade_id_get(self, trade_id: int, db: AsyncSession) -> TradeResponse:
+        return TradeResponse()
+
+    async def trades_trade_id_is_checked_put(self, trade_id: int, update_is_checked_request: UpdateIsCheckedRequest, db: AsyncSession) -> None:
+        return None
+
+    async def trades_trade_id_put(self, trade_id: int, update_trade_request: UpdateTradeRequest, db: AsyncSession) -> TradeResponse:
+        return None

--- a/backend/src/openapi_server/models/request_trade_request.py
+++ b/backend/src/openapi_server/models/request_trade_request.py
@@ -32,10 +32,10 @@ class RequestTradeRequest(BaseModel):
     """
     RequestTradeRequest
     """ # noqa: E501
-    furniture_id: StrictInt = Field(alias="furnitureId")
-    user_id: StrictInt = Field(alias="userId")
+    furniture_id: StrictInt = Field(alias="furniture_id")
+    user_id: StrictInt = Field(alias="user_id")
     trade_date: date
-    __properties: ClassVar[List[str]] = ["furnitureId", "userId", "trade_date"]
+    __properties: ClassVar[List[str]] = ["furniture_id", "user_id", "trade_date"]
 
     model_config = {
         "populate_by_name": True,
@@ -86,8 +86,8 @@ class RequestTradeRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "furnitureId": obj.get("furnitureId"),
-            "userId": obj.get("userId"),
+            "furniture_id": obj.get("furniture_id"),
+            "user_id": obj.get("user_id"),
             "trade_date": obj.get("trade_date")
         })
         return _obj

--- a/backend/src/openapi_server/models/trade_response.py
+++ b/backend/src/openapi_server/models/trade_response.py
@@ -32,19 +32,19 @@ class TradeResponse(BaseModel):
     """
     TradeResponse
     """ # noqa: E501
-    trade_id: Optional[StrictInt] = Field(default=None, alias="tradeId")
+    trade_id: Optional[StrictInt] = Field(default=None, alias="trade_id")
     image: Optional[Union[StrictBytes, StrictStr]] = None
     receiver_name: Optional[StrictStr] = None
     product_name: Optional[StrictStr] = None
     trade_place: Optional[StrictStr] = Field(default=None, description="具体的な取引場所")
-    furniture_id: Optional[StrictInt] = Field(default=None, alias="furnitureId")
-    giver_id: Optional[StrictInt] = Field(default=None, alias="giverId")
-    receiver_id: Optional[StrictInt] = Field(default=None, alias="receiverId")
+    furniture_id: Optional[StrictInt] = Field(default=None, alias="furniture_id")
+    giver_id: Optional[StrictInt] = Field(default=None, alias="giver_id")
+    receiver_id: Optional[StrictInt] = Field(default=None, alias="receiver_id")
     is_checked: Optional[StrictBool] = None
     giver_approval: Optional[StrictBool] = None
     receiver_approval: Optional[StrictBool] = None
     trade_date: Optional[date] = None
-    __properties: ClassVar[List[str]] = ["tradeId", "image", "receiver_name", "product_name", "trade_place", "furnitureId", "giverId", "receiverId", "is_checked", "giver_approval", "receiver_approval", "trade_date"]
+    __properties: ClassVar[List[str]] = ["trade_id", "image", "receiver_name", "product_name", "trade_place", "furniture_id", "giver_id", "receiver_id", "is_checked", "giver_approval", "receiver_approval", "trade_date"]
 
     model_config = {
         "populate_by_name": True,
@@ -95,14 +95,14 @@ class TradeResponse(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "tradeId": obj.get("tradeId"),
+            "trade_id": obj.get("trade_id"),
             "image": obj.get("image"),
             "receiver_name": obj.get("receiver_name"),
             "product_name": obj.get("product_name"),
             "trade_place": obj.get("trade_place"),
-            "furnitureId": obj.get("furnitureId"),
-            "giverId": obj.get("giverId"),
-            "receiverId": obj.get("receiverId"),
+            "furniture_id": obj.get("furniture_id"),
+            "giver_id": obj.get("giver_id"),
+            "receiver_id": obj.get("receiver_id"),
             "is_checked": obj.get("is_checked"),
             "giver_approval": obj.get("giver_approval"),
             "receiver_approval": obj.get("receiver_approval"),

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -530,13 +530,13 @@ components:
     RequestTradeRequest:
       type: object
       required:
-        - furnitureId
-        - userId
+        - furniture_id
+        - user_id
         - trade_date
       properties:
-        furnitureId:
+        furniture_id:
           type: integer
-        userId:
+        user_id:
           type: integer
         trade_date:
           type: string
@@ -544,7 +544,7 @@ components:
     TradeResponse:
       type: object
       properties:
-        tradeId:
+        trade_id:
           type: integer
         image:
           type: string
@@ -556,11 +556,11 @@ components:
         trade_place:
           type: string
           description: 具体的な取引場所
-        furnitureId:
+        furniture_id:
           type: integer
-        giverId:
+        giver_id:
           type: integer
-        receiverId:
+        receiver_id:
           type: integer
         is_checked:
           type: boolean


### PR DESCRIPTION
## issue番号

#20 
#24 

## やったこと(簡単でOK)
- 商品の取引の依頼API実装 (post /trades)
- 商品の取引履歴取得API実装 (get /trades)
- 商品の取引詳細API実装 (get /trades/{trade_id})
- 取引の確認API実装 (put /trades/{trade_id}/is_checked)
- 商品取引完了API実装 (put /trades/{trade_id})

## その他(Option)
- 取引完了のAPIは一度完了を押したら取り消すことはできません
- 双方が取引完了した場合はFurniture Tableのis_soldがTrueになります

Closes #20 
Closes #24 
