### PR TITLE
TradeのOpenAPIの定義を適応

### DIFF
--- a/backend/.openapi-generator-ignore
+++ b/backend/.openapi-generator-ignore
@@ -25,3 +25,4 @@ src/openapi_server/apis/ok_api.py
 src/openapi_server/apis/furniture_api.py
 src/openapi_server/apis/user_api.py
 src/openapi_server/apis/favorite_api.py
+src/openapi_server/apis/trade_api.py

--- a/backend/.openapi-generator/FILES
+++ b/backend/.openapi-generator/FILES
@@ -3,10 +3,7 @@ openapi.yaml
 setup.cfg
 src/openapi_server/apis/__init__.py
 src/openapi_server/apis/favorite_api_base.py
-src/openapi_server/apis/furniture_api.py
-src/openapi_server/apis/furniture_api_base.py
 src/openapi_server/apis/ok_api_base.py
-src/openapi_server/apis/trade_api.py
 src/openapi_server/apis/trade_api_base.py
 src/openapi_server/apis/user_api_base.py
 src/openapi_server/models/__init__.py

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -720,8 +720,8 @@ components:
       type: object
     RequestTradeRequest:
       example:
-        furniture_id: 0
         user_id: 6
+        furniture_id: 0
         trade_date: 2000-01-23
       properties:
         furniture_id:
@@ -743,9 +743,9 @@ components:
     TradeResponse:
       example:
         image: ""
-        giver_id: 1
-        receiver_id: 5
+        trade_id: 0
         giver_approval: true
+        receiver_id: 5
         receiver_approval: true
         receiver_name: receiver_name
         is_checked: true
@@ -753,7 +753,7 @@ components:
         furniture_id: 6
         product_name: product_name
         trade_date: 2000-01-23
-        trade_id: 0
+        giver_id: 1
       properties:
         trade_id:
           title: trade_id
@@ -800,9 +800,9 @@ components:
       example:
         trades:
         - image: ""
-          giver_id: 1
-          receiver_id: 5
+          trade_id: 0
           giver_approval: true
+          receiver_id: 5
           receiver_approval: true
           receiver_name: receiver_name
           is_checked: true
@@ -810,11 +810,11 @@ components:
           furniture_id: 6
           product_name: product_name
           trade_date: 2000-01-23
-          trade_id: 0
+          giver_id: 1
         - image: ""
-          giver_id: 1
-          receiver_id: 5
+          trade_id: 0
           giver_approval: true
+          receiver_id: 5
           receiver_approval: true
           receiver_name: receiver_name
           is_checked: true
@@ -822,7 +822,7 @@ components:
           furniture_id: 6
           product_name: product_name
           trade_date: 2000-01-23
-          trade_id: 0
+          giver_id: 1
       properties:
         trades:
           items:

--- a/backend/src/openapi_server/models/request_trade_request.py
+++ b/backend/src/openapi_server/models/request_trade_request.py
@@ -21,7 +21,7 @@ import json
 
 
 from datetime import date
-from pydantic import BaseModel, ConfigDict, Field, StrictInt
+from pydantic import BaseModel, ConfigDict, StrictInt
 from typing import Any, ClassVar, Dict, List
 try:
     from typing import Self
@@ -32,8 +32,8 @@ class RequestTradeRequest(BaseModel):
     """
     RequestTradeRequest
     """ # noqa: E501
-    furniture_id: StrictInt = Field(alias="furniture_id")
-    user_id: StrictInt = Field(alias="user_id")
+    furniture_id: StrictInt
+    user_id: StrictInt
     trade_date: date
     __properties: ClassVar[List[str]] = ["furniture_id", "user_id", "trade_date"]
 

--- a/backend/src/openapi_server/models/trade_response.py
+++ b/backend/src/openapi_server/models/trade_response.py
@@ -32,14 +32,14 @@ class TradeResponse(BaseModel):
     """
     TradeResponse
     """ # noqa: E501
-    trade_id: Optional[StrictInt] = Field(default=None, alias="trade_id")
+    trade_id: Optional[StrictInt] = None
     image: Optional[Union[StrictBytes, StrictStr]] = None
     receiver_name: Optional[StrictStr] = None
     product_name: Optional[StrictStr] = None
     trade_place: Optional[StrictStr] = Field(default=None, description="具体的な取引場所")
-    furniture_id: Optional[StrictInt] = Field(default=None, alias="furniture_id")
-    giver_id: Optional[StrictInt] = Field(default=None, alias="giver_id")
-    receiver_id: Optional[StrictInt] = Field(default=None, alias="receiver_id")
+    furniture_id: Optional[StrictInt] = None
+    giver_id: Optional[StrictInt] = None
+    receiver_id: Optional[StrictInt] = None
     is_checked: Optional[StrictBool] = None
     giver_approval: Optional[StrictBool] = None
     receiver_approval: Optional[StrictBool] = None


### PR DESCRIPTION
## やったこと(簡単でOK)

OpenAPIのgeneratorでAPI定義との差分も修正

## レビューしてほしいこと(要確認)

`backend/src/openapi_server/models/request_trade_request.py`と`backend/src/openapi_server/models/trade_response.py`をOpenAPIに従って変更してもいいか(aliasが消える)

変更不可であれば`backend/.openapi-generator-ignore`に記入しますー

## その他(Option)

