### PR TITLE
GET /furniture/ のBodyをqueryパラメータに変更

### DIFF
--- a/backend/.openapi-generator/FILES
+++ b/backend/.openapi-generator/FILES
@@ -3,6 +3,8 @@ openapi.yaml
 setup.cfg
 src/openapi_server/apis/__init__.py
 src/openapi_server/apis/favorite_api_base.py
+src/openapi_server/apis/furniture_api.py
+src/openapi_server/apis/furniture_api_base.py
 src/openapi_server/apis/ok_api_base.py
 src/openapi_server/apis/trade_api_base.py
 src/openapi_server/apis/user_api_base.py
@@ -11,9 +13,7 @@ src/openapi_server/models/error_response.py
 src/openapi_server/models/extra_models.py
 src/openapi_server/models/favorite_response.py
 src/openapi_server/models/furniture_describe_response.py
-src/openapi_server/models/furniture_list_request.py
 src/openapi_server/models/furniture_list_response.py
-src/openapi_server/models/furniture_request.py
 src/openapi_server/models/furniture_response.py
 src/openapi_server/models/login_request.py
 src/openapi_server/models/login_response.py

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -84,11 +84,24 @@ paths:
       - User
   /furniture:
     get:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FurnitureListRequest'
+      parameters:
+      - example: 1
+        explode: true
+        in: query
+        name: user_id
+        required: true
+        schema:
+          type: integer
+        style: form
+      - description: "検索キーワード, スペース区切りで複数指定可"
+        example: ソファ かわいい
+        explode: true
+        in: query
+        name: keyword
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -140,18 +153,22 @@ paths:
       - Furniture
     get:
       parameters:
-      - explode: false
+      - example: 1
+        explode: false
         in: path
         name: furniture_id
         required: true
         schema:
           type: integer
         style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FurnitureRequest'
+      - example: 2
+        explode: true
+        in: query
+        name: user_id
+        required: true
+        schema:
+          type: integer
+        style: form
       responses:
         "200":
           content:
@@ -529,33 +546,6 @@ components:
       - trade_place
       - user_id
       - width
-      type: object
-    FurnitureRequest:
-      example:
-        user_id: 0
-      properties:
-        user_id:
-          title: user_id
-          type: integer
-      required:
-      - user_id
-      title: FurnitureRequest
-      type: object
-    FurnitureListRequest:
-      example:
-        user_id: 0
-        keyword: keyword
-      properties:
-        user_id:
-          title: user_id
-          type: integer
-        keyword:
-          description: "検索キーワード, スペース区切りで複数指定可"
-          title: keyword
-          type: string
-      required:
-      - user_id
-      title: FurnitureListRequest
       type: object
     FurnitureListResponse:
       example:

--- a/backend/src/openapi_server/apis/furniture_api.py
+++ b/backend/src/openapi_server/apis/furniture_api.py
@@ -25,11 +25,8 @@ from fastapi import (  # noqa: F401
 from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.models.error_response import ErrorResponse
 from openapi_server.models.furniture_describe_response import FurnitureDescribeResponse
-from openapi_server.models.furniture_list_request import FurnitureListRequest
 from openapi_server.models.furniture_list_response import FurnitureListResponse
-from openapi_server.models.furniture_request import FurnitureRequest
 from openapi_server.models.furniture_response import FurnitureResponse
-from openapi_server.models.register_furniture_request import RegisterFurnitureRequest
 
 from openapi_server.impl.furniture_api_impl import FurnitureApiImpl
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -89,10 +86,10 @@ async def furniture_furniture_id_delete(
 )
 async def furniture_furniture_id_get(
     furniture_id: int = Path(..., description=""),
-    furniture_request: FurnitureRequest = Body(None, description=""),
+    user_id: int = Query(None, description="", alias="user_id"),
     db: AsyncSession = Depends(get_db),
 ) -> FurnitureResponse:
-    return await impl.furniture_furniture_id_get(furniture_id, furniture_request.user_id, db)
+    return await impl.furniture_furniture_id_get(furniture_id, user_id, db)
 
 
 @router.get(
@@ -105,10 +102,11 @@ async def furniture_furniture_id_get(
     response_model_by_alias=True,
 )
 async def furniture_get(
-    furniture_list_request: FurnitureListRequest = Body(None, description=""),
+    user_id: int = Query(None, description="", alias="user_id"),
+    keyword: str = Query(None, description="検索キーワード, スペース区切りで複数指定可", alias="keyword"),
     db: AsyncSession = Depends(get_db),
 ) -> FurnitureListResponse:
-    return await impl.furniture_get(furniture_list_request, db)
+    return await impl.furniture_get(user_id, keyword, db)
 
 
 @router.post(

--- a/backend/src/openapi_server/apis/furniture_api_base.py
+++ b/backend/src/openapi_server/apis/furniture_api_base.py
@@ -4,9 +4,7 @@ from typing import ClassVar, Dict, List, Tuple  # noqa: F401
 
 from openapi_server.models.error_response import ErrorResponse
 from openapi_server.models.furniture_describe_response import FurnitureDescribeResponse
-from openapi_server.models.furniture_list_request import FurnitureListRequest
 from openapi_server.models.furniture_list_response import FurnitureListResponse
-from openapi_server.models.furniture_request import FurnitureRequest
 from openapi_server.models.furniture_response import FurnitureResponse
 
 from fastapi import UploadFile
@@ -35,14 +33,15 @@ class BaseFurnitureApi:
     def furniture_furniture_id_get(
         self,
         furniture_id: int,
-        furniture_request: FurnitureRequest,
+        user_id: int,
     ) -> FurnitureResponse:
         ...
 
 
     def furniture_get(
         self,
-        furniture_list_request: FurnitureListRequest,
+        user_id: int,
+        keyword: str,
     ) -> FurnitureListResponse:
         ...
 

--- a/backend/src/openapi_server/impl/furniture_api_impl.py
+++ b/backend/src/openapi_server/impl/furniture_api_impl.py
@@ -6,7 +6,6 @@ import uuid
 from openapi_server.apis.furniture_api_base import BaseFurnitureApi
 
 from openapi_server.models.furniture_list_response import FurnitureListResponse
-from openapi_server.models.furniture_list_request import FurnitureListRequest
 from openapi_server.models.furniture_response import FurnitureResponse
 from openapi_server.models.furniture_describe_response import FurnitureDescribeResponse
 
@@ -68,11 +67,10 @@ class FurnitureApiImpl(BaseFurnitureApi):
 
     async def furniture_get(
         self,
-        furniture_list_request: FurnitureListRequest,
+        user_id: int,
+        keyword: Optional[str],
         db: AsyncSession,
     ) -> FurnitureListResponse:
-        user_id = furniture_list_request.user_id
-        keyword: Optional[str] = furniture_list_request.keyword
         furniture_list: FurnitureListResponse = await furniture_crud.get_furniture_list(db, user_id, keyword)
 
         if furniture_list is None:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -105,11 +105,19 @@ paths:
       tags:
         - Furniture
       summary: Get list of furniture
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FurnitureListRequest'
+      parameters:
+        - name: user_id
+          in: query
+          required: true
+          schema:
+            type: integer
+          example: 1
+        - name: keyword
+          in: query
+          schema:
+            type: string
+          description: 検索キーワード, スペース区切りで複数指定可
+          example: "ソファ かわいい"
       responses:
         '200':
           description: Furniture list retrieved successfully
@@ -128,11 +136,13 @@ paths:
           required: true
           schema:
             type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FurnitureRequest'
+          example: 1
+        - name: user_id
+          in: query
+          required: true
+          schema:
+            type: integer
+          example: 2
       responses:
         '200':
           description: Furniture details retrieved successfully
@@ -485,23 +495,6 @@ components:
           type: string
         condition:
           type: integer
-    FurnitureRequest:
-      type: object
-      required:
-        - user_id
-      properties:
-        user_id:
-          type: integer
-    FurnitureListRequest:
-      type: object
-      required:
-        - user_id
-      properties:
-        user_id:
-          type: integer
-        keyword:
-          type: string
-          description: 検索キーワード, スペース区切りで複数指定可
     FurnitureListResponse:
       type: object
       properties:


### PR DESCRIPTION
## issue番号

#96 

## やったこと(簡単でOK)

- 以下2つのAPI定義を変更し、リクエストボディをqueryパラメータに変更
  - GET /furniture
  - GET /furniture/{furniture_id}
- 上記の変更に伴い`openapi_server/impl/furniture_api_impl.py`も軽く修正

## その他(Option)

closes #96 
