### PR TITLE
Favorite APIに適切な例外処理を追加

### DIFF
--- a/backend/src/openapi_server/impl/favorite_api_impl.py
+++ b/backend/src/openapi_server/impl/favorite_api_impl.py
@@ -3,6 +3,7 @@ from openapi_server.models.favorite_response import FavoriteResponse
 import openapi_server.cruds.favorite as favorite_crud
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException, status
 
 
 class FavoriteApiImpl(BaseFavoriteApi):
@@ -12,7 +13,9 @@ class FavoriteApiImpl(BaseFavoriteApi):
         user_id: int,
         db: AsyncSession,
     ) -> None:
-        return await favorite_crud.delete_favorite(db, furniture_id, user_id)
+        is_deleted = await favorite_crud.delete_favorite(db, furniture_id, user_id)
+        if not is_deleted:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found")
 
 
     async def favorite_furniture_id_get(
@@ -20,7 +23,7 @@ class FavoriteApiImpl(BaseFavoriteApi):
         furniture_id: int,
         db: AsyncSession,
     ) -> FavoriteResponse:
-        favorites_count: int = await favorite_crud.get_favorite_count_by_furniture_id(db, furniture_id)
+        favorites_count = await favorite_crud.count_favorite_by_furniture_id(db, furniture_id)
         return FavoriteResponse(favorites_count=favorites_count)
 
 
@@ -30,4 +33,6 @@ class FavoriteApiImpl(BaseFavoriteApi):
         user_id: int,
         db: AsyncSession,
     ) -> None:
-        return await favorite_crud.create_favorite(db, furniture_id, user_id)
+        is_created = await favorite_crud.create_favorite(db, furniture_id, user_id)
+        if not is_created:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Favorite already exists")


### PR DESCRIPTION
## issue番号

#102 

## やったこと(簡単でOK)

- いいねをするAPI
  - 同じ人が同じ家具にいいねをした場合、何もせずにstatus 200だけ返していたが、status 400を返す
- いいねを取り消すAPI
  - 存在しないfurniture_idが渡された場合、何もせずにstatus 200だけ返していたが、status 404を返す

## その他(Option)

いいね数を取得するAPIで、存在しないfurniture_idが渡された場合に0を返却する挙動はそのままにする

Closes #102 
